### PR TITLE
Upgrade Node.js version from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: index.cjs
 
 branding:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-addon",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Publish add-on to Microsoft Edge Add-ons.",
   "author": "hyperbola",
   "license": "MIT",


### PR DESCRIPTION
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

@ maintainers: feel free to adjust :)